### PR TITLE
feat: update policy permissions to share an asset

### DIFF
--- a/src/core/usecases/share-footprint.ts
+++ b/src/core/usecases/share-footprint.ts
@@ -7,7 +7,7 @@ export class ShareFootprintUsecase {
   async share(data: ShareFootprintInput) {
     const assetInput = builder.assetInput(data);
     const asset = await this.edcClient.createAsset(assetInput);
-    const policyInput = builder.policyInput();
+    const policyInput = builder.policyInput(asset.id);
     const policy = await this.edcClient.createPolicy(policyInput);
     const contractDefinitionInput = builder.contractDefinition({
       accessPolicyId: policy.id,

--- a/src/utils/edc-builder.ts
+++ b/src/utils/edc-builder.ts
@@ -28,16 +28,29 @@ export function assetInput(
 }
 
 export function policyInput(
+  assetId: string,
   props: Partial<PolicyDefinitionInput> = {}
 ): PolicyDefinitionInput {
+  const permissions = [
+    {
+      target: assetId,
+      action: {
+        type: 'USE',
+      },
+      edctype: 'dataspaceconnector:permission',
+    },
+  ];
+
   return defaults(props, {
     policy: {
+      permissions: permissions,
       '@type': {
-        '@policytype': 'offer',
+        '@policytype': 'set',
       },
     },
   });
 }
+
 export function contractDefinition(
   props: Partial<ContractDefinition> = {}
 ): ContractDefinition {


### PR DESCRIPTION
## Description
This PR updates the policy builder to include the asset created in the permissions (in other words, the policy now will give access policy to the previously created asset).

### How to test it
- Have the connector images running
- execute this in your terminal
``` 
curl -H 'Content-Type: application/json' \
    -d '{
        "shipmentId": "shipmentId",
        "dataAddress": {
            "properties": {
                "uid": "1",
                "name": "An AmazonS3 resource'\''s name",
                "bucketName": "bucket-name",
                "region": "eu-west-1",
                "type": "AmazonS3"
            }
        }
    }' \
    -X POST "http://localhost:3000/emissions"

```
