### PR TITLE
feat: create data catalog request endpoint and controller

### DIFF
--- a/src/api/routes/emissions.ts
+++ b/src/api/routes/emissions.ts
@@ -1,10 +1,18 @@
 import KoaRouter from '@koa/router';
-import { FootPrintController } from '../../core/controllers';
+import {
+  ConsumeFootPrintController,
+  ProvideFootPrintController,
+} from '../../core/controllers';
 
 export const edcRouter = new KoaRouter()
-  .post('Share a PCF', '/emissions', FootPrintController.shareFootprints)
+  .post('Share a PCF', '/emissions', ProvideFootPrintController.shareFootprints)
   .get(
     'Get shared PCFs',
     '/emissions/sent',
-    FootPrintController.getSharedFootprints
+    ProvideFootPrintController.getSharedFootprints
+  )
+  .post(
+    'Request a data catalog from a connector',
+    '/catalog',
+    ConsumeFootPrintController.requestFootprintsCatalogs
   );

--- a/src/core/clients/EdcClient.ts
+++ b/src/core/clients/EdcClient.ts
@@ -1,9 +1,14 @@
 import {
   EdcConnectorClient,
   EdcConnectorClientContext,
-  PolicyDefinitionInput,
 } from '@think-it-labs/edc-connector-client';
-import { Connector, AssetInput, ContractDefinitionInput } from '../entities';
+import {
+  Connector,
+  AssetInput,
+  ContractDefinitionInput,
+  CatalogRequest,
+  PolicyDefinitionInput,
+} from '../entities';
 
 export class EdcAdapter {
   readonly edcConnectorClient: EdcConnectorClient;
@@ -51,6 +56,13 @@ export class EdcAdapter {
   async listContractDefinitions() {
     return this.edcConnectorClient.management.queryAllContractDefinitions(
       this.edcClientContext
+    );
+  }
+
+  async listCatalogs(input: CatalogRequest) {
+    return this.edcConnectorClient.management.requestCatalog(
+      this.edcClientContext,
+      input
     );
   }
 }

--- a/src/core/controllers/consumeFootprint.ts
+++ b/src/core/controllers/consumeFootprint.ts
@@ -1,0 +1,24 @@
+import { RouterContext } from '@koa/router';
+import { ShareFootprintInput, CatalogRequest } from '../entities';
+import { InvalidInput } from '../error';
+import { consumeFootprintUsecase } from '../usecases';
+
+export class ConsumeFootPrintController {
+  static async requestFootprintsCatalogs(context: RouterContext) {
+    try {
+      const response = await consumeFootprintUsecase.listCatalogs(
+        context.request.body as CatalogRequest
+      );
+      context.body = response.body;
+      context.status = 200;
+    } catch (error) {
+      console.log(error);
+      if (error instanceof InvalidInput) {
+        context.status = 400;
+        return;
+      }
+
+      context.status = 500;
+    }
+  }
+}

--- a/src/core/controllers/index.ts
+++ b/src/core/controllers/index.ts
@@ -1,1 +1,2 @@
-export * from './footprint';
+export * from './provideFootprint';
+export * from './consumeFootprint';

--- a/src/core/controllers/provideFootprint.ts
+++ b/src/core/controllers/provideFootprint.ts
@@ -1,12 +1,12 @@
 import { RouterContext } from '@koa/router';
-import { ShareFootprintInput } from '../../core/entities';
+import { ShareFootprintInput } from '../entities';
 import { InvalidInput } from '../error';
-import { shareFootprintUsecase } from '../usecases';
+import { provideFootprintUsecase } from '../usecases';
 
-export class FootPrintController {
+export class ProvideFootPrintController {
   static async shareFootprints(context: RouterContext) {
     try {
-      const response = await shareFootprintUsecase.share(
+      const response = await provideFootprintUsecase.share(
         context.request.body as ShareFootprintInput
       );
       context.body = response.body;
@@ -24,7 +24,7 @@ export class FootPrintController {
 
   static async getSharedFootprints(context: RouterContext) {
     try {
-      const response = await shareFootprintUsecase.list();
+      const response = await provideFootprintUsecase.list();
       context.body = response.body;
       context.status = 200;
     } catch (error) {

--- a/src/core/entities/edc-connector-client.ts
+++ b/src/core/entities/edc-connector-client.ts
@@ -4,6 +4,7 @@ export type {
   ApiErrorDetail,
   Asset,
   AssetInput,
+  CatalogRequest,
   Constraint,
   ContractDefinition,
   ContractDefinitionInput,

--- a/src/core/usecases/consume-footprint.ts
+++ b/src/core/usecases/consume-footprint.ts
@@ -1,0 +1,12 @@
+import { EdcAdapter } from '../clients/EdcClient';
+import { CatalogRequest, ShareFootprintInput } from '../entities';
+export class ConsumeFootprintUsecase {
+  constructor(private edcClient: EdcAdapter) {}
+
+  async listCatalogs(input: CatalogRequest) {
+    const assets = await this.edcClient.listCatalogs(input);
+    return {
+      body: assets,
+    };
+  }
+}

--- a/src/core/usecases/index.ts
+++ b/src/core/usecases/index.ts
@@ -1,4 +1,6 @@
 import { edcAdapter } from '../../core/clients';
-import { ShareFootprintUsecase } from './share-footprint';
+import { ProvideFootprintUsecase } from './provide-footprint';
+import { ConsumeFootprintUsecase } from './consume-footprint';
 
-export const shareFootprintUsecase = new ShareFootprintUsecase(edcAdapter);
+export const provideFootprintUsecase = new ProvideFootprintUsecase(edcAdapter);
+export const consumeFootprintUsecase = new ConsumeFootprintUsecase(edcAdapter);

--- a/src/core/usecases/provide-footprint.ts
+++ b/src/core/usecases/provide-footprint.ts
@@ -1,7 +1,7 @@
-import { EdcAdapter } from '../../core/clients/EdcClient';
-import { ShareFootprintInput } from '../../core/entities';
+import { EdcAdapter } from '../clients/EdcClient';
+import { ShareFootprintInput } from '../entities';
 import * as builder from '../../utils/edc-builder';
-export class ShareFootprintUsecase {
+export class ProvideFootprintUsecase {
   constructor(private edcClient: EdcAdapter) {}
 
   async share(data: ShareFootprintInput) {


### PR DESCRIPTION
## Description
This PR resolves #29 

### How to test it
```
curl -H 'Content-Type: application/json' \    
    -d '{
        "providerUrl": "http://provider-connector:9194/api/v1/ids/data"
    }' \
    -X POST "http://localhost:3000/catalog"
```

### Addition context
the `providerUrl` value is the **IDS** url of the connector you are requesting.
Example: 
- I am a shipper and I have a connector A, you are a LSP and you have connector B
- I, as a shipper, want to check your catalog offers
- I, as a shipper, will send a `POST` request with a similar body:
`
{
        "providerUrl": "http://connectorB-address/api/v1/ids/data"
}
`