### PR TITLE
feat: add endpoint that displays catalog filtered by shipmentId

### DIFF
--- a/src/api/routes/emissions.ts
+++ b/src/api/routes/emissions.ts
@@ -14,5 +14,10 @@ export const edcRouter = new KoaRouter()
   .post(
     'Request a data catalog from a connector',
     '/catalog',
-    ConsumeFootPrintController.requestFootprintsCatalogs
+    ConsumeFootPrintController.requestFootprintsCatalog
+  )
+  .post(
+    'Request a data catalog from a connector with shipment filter',
+    '/catalog/:shipmentId',
+    ConsumeFootPrintController.requestFilteredFootprintsCatalog
   );

--- a/src/core/clients/EdcClient.ts
+++ b/src/core/clients/EdcClient.ts
@@ -59,8 +59,14 @@ export class EdcAdapter {
     );
   }
 
-  async listCatalogs(input: CatalogRequest) {
+  async listCatalog(input: CatalogRequest) {
     return this.edcConnectorClient.management.requestCatalog(
+      this.edcClientContext,
+      input
+    );
+  }
+  async queryAllPolicies(input) {
+    return this.edcConnectorClient.management.queryAllPolicies(
       this.edcClientContext,
       input
     );

--- a/src/core/controllers/consumeFootprint.ts
+++ b/src/core/controllers/consumeFootprint.ts
@@ -1,10 +1,10 @@
 import { RouterContext } from '@koa/router';
-import { CatalogRequest } from 'core/entities';
-import { InvalidInput } from 'core/error';
+import { CatalogRequest } from '../entities';
+import { InvalidInput } from '../error';
 import { consumeFootprintUsecase } from '../usecases';
 
 export class ConsumeFootPrintController {
-  static async requestFootprintsCatalogs(context: RouterContext) {
+  static async requestFootprintsCatalog(context: RouterContext) {
     try {
       const response = await consumeFootprintUsecase.listCatalogs(
         context.request.body as CatalogRequest
@@ -18,6 +18,24 @@ export class ConsumeFootPrintController {
         return;
       }
 
+      context.status = 500;
+    }
+  }
+  static async requestFilteredFootprintsCatalog(context: RouterContext) {
+    try {
+      const { shipmentId } = context.params;
+      const response = await consumeFootprintUsecase.listFilteredCatalog(
+        context.request.body as CatalogRequest,
+        shipmentId
+      );
+      context.body = response.body;
+      context.status = 200;
+    } catch (error) {
+      console.log(error);
+      if (error instanceof InvalidInput) {
+        context.status = 400;
+        return;
+      }
       context.status = 500;
     }
   }

--- a/src/core/usecases/consume-footprint.ts
+++ b/src/core/usecases/consume-footprint.ts
@@ -1,10 +1,23 @@
 import { EdcAdapter } from '../clients/EdcClient';
-import { CatalogRequest, ShareFootprintInput } from '../entities';
+import { CatalogRequest } from '../entities';
+import * as builder from '../../utils/edc-builder';
+
 export class ConsumeFootprintUsecase {
   constructor(private edcClient: EdcAdapter) {}
 
   async listCatalogs(input: CatalogRequest) {
-    const assets = await this.edcClient.listCatalogs(input);
+    const assets = await this.edcClient.listCatalog(input);
+    return {
+      body: assets,
+    };
+  }
+
+  async listFilteredCatalog(input: CatalogRequest, shipmentId: string) {
+    const assetFilter = builder.catalogAssetFilter(shipmentId);
+    const assets = await this.edcClient.listCatalog({
+      ...input,
+      querySpec: assetFilter,
+    });
     return {
       body: assets,
     };

--- a/src/utils/edc-builder.ts
+++ b/src/utils/edc-builder.ts
@@ -2,6 +2,7 @@ import {
   AssetInput,
   ContractDefinition,
   PolicyDefinitionInput,
+  QuerySpec,
   ShareFootprintInput,
 } from '../core/entities';
 import { defaults } from 'lodash';
@@ -58,4 +59,16 @@ export function contractDefinition(
     id: randomUid(),
     criteria: [],
   });
+}
+
+export function catalogAssetFilter(assetId: string): QuerySpec {
+  return {
+    filterExpression: [
+      {
+        operandLeft: 'asset:prop:id',
+        operandRight: assetId,
+        operator: '=',
+      },
+    ],
+  };
 }


### PR DESCRIPTION
## Description
This PR resolves #23 and adds an enpoint that accepts `shipmentId` as a query param, and filters the data catalog with the `shipmentId` value

### How to test it
- set `CONNECTOR_CONFIG`in the `.env` file to the **provider** connector addresses
- run the project
- share two different shipments (under two different IDs)
- stop the dev server, change the `.env` file and set `CONNECTOR_CONFIG` to the **consumer** connector addresses
- execute this command on your terminal to test the new endpoint 
``` 
curl -H 'Content-Type: application/json' \
    -d '{
        "providerUrl": "http://provider-connector:9194/api/v1/ids/data"
    }' \
    -X POST "http://localhost:3000/catalog/hehe"
```
