### PR TITLE
chore: drop dataplanes creation

### DIFF
--- a/src/entities/edc-connector-client.ts
+++ b/src/entities/edc-connector-client.ts
@@ -13,7 +13,6 @@ export type {
   ContractNegotiationRequest,
   CreateResult,
   Criterion,
-  DataplaneInput,
   Duty,
   HealthCheckResult,
   HealthStatus,

--- a/src/participants/clients/edc-client.ts
+++ b/src/participants/clients/edc-client.ts
@@ -3,7 +3,6 @@ import {
   CatalogRequest,
   ContractDefinitionInput,
   ContractNegotiationRequest,
-  DataplaneInput,
   EdcConnectorClient,
   EdcConnectorClientContext,
   PolicyDefinitionInput,
@@ -108,12 +107,6 @@ export class EdcAdapter {
   }
   async initiateTransfer(input: TransferProcessInput) {
     return this.edcConnectorClient.management.initiateTransfer(
-      this.edcClientContext,
-      input
-    );
-  }
-  async registerDataplane(input: DataplaneInput) {
-    return this.edcConnectorClient.management.registerDataplane(
       this.edcClientContext,
       input
     );

--- a/src/participants/usecases/initiate-file-transfer.ts
+++ b/src/participants/usecases/initiate-file-transfer.ts
@@ -4,7 +4,7 @@ import { ContractNotFound } from 'utils/error';
 import { validateSchema } from 'utils/helpers';
 import * as builder from '../utils/edc-builder';
 import { ParticipantType } from 'entities/client-types';
-import { Addresses, ContractNegotiationState, ContractOffer } from 'entities';
+import { ContractNegotiationState, ContractOffer } from 'entities';
 import { ContractAgreement } from '@think-it-labs/edc-connector-client';
 
 const inputSchema = {
@@ -24,18 +24,7 @@ export class InitiateFileTransferUsecase {
     validateSchema(inputData, inputSchema);
 
     const { clientId, shipmentId } = inputData;
-
     const provider = await this.getProvider(authorization, clientId);
-
-    await this.registerDataplane(
-      provider.client_id,
-      provider.connector_data.addresses
-    );
-
-    await this.registerDataplane(
-      this.edcClient.edcClientId,
-      this.edcClient.edcClientContext
-    );
 
     const contractAgreementId = await this.getContractAgreementId(shipmentId);
     if (contractAgreementId) {
@@ -164,10 +153,5 @@ export class InitiateFileTransferUsecase {
       return undefined;
     }
     return response[0].id;
-  }
-
-  async registerDataplane(clientId: string, connectorAddresses: Addresses) {
-    const dataPlaneInput = builder.dataplaneInput(clientId, connectorAddresses);
-    await this.edcClient.registerDataplane(dataPlaneInput);
   }
 }

--- a/src/participants/utils/edc-builder.ts
+++ b/src/participants/utils/edc-builder.ts
@@ -4,7 +4,6 @@ import {
   ContractOffer,
   ContractNegotiationRequest,
   DataAddressType,
-  DataplaneInput,
   IDS_PROTOCOL,
   PolicyDefinitionInput,
   QuerySpec,
@@ -124,20 +123,5 @@ export function transferProcessInput(
     contractId: contractId,
     dataDestination: { type: DataAddressType.HttpType },
     managedResources: false,
-  };
-}
-
-export function dataplaneInput(
-  clientId: string,
-  connectorAddresses: Addresses
-): DataplaneInput {
-  return {
-    id: `${clientId}-dataplane`,
-    url: `${connectorAddresses.control}/transfer`,
-    allowedSourceTypes: ['HttpData'],
-    allowedDestTypes: ['HttpProxy', 'HttpData'],
-    properties: {
-      publicApiUrl: connectorAddresses.public,
-    },
   };
 }


### PR DESCRIPTION
## Description
This is just a clean-up for the consumer controller to remove any method that involved dataplanes instances creation.
The PR resolves #65 

### How to test it
Everything should be still working like usual. 
