### PR TITLE
feat: revoke access to assets

### DIFF
--- a/src/participants/routes/emissions.ts
+++ b/src/participants/routes/emissions.ts
@@ -18,6 +18,12 @@ export const edcRouter = new KoaRouter({ prefix: '/emissions' })
     AuthController.authMiddleware,
     ProvideFootPrintController.getSharedFootprints
   )
+  .delete(
+    'Revoke access to a shipment',
+    '/sent/:shipmentId',
+    ProvideFootPrintController.unshareFootprint
+  )
+
   .get(
     'Request a data catalog from a connector',
     '/catalog',
@@ -29,11 +35,10 @@ export const edcRouter = new KoaRouter({ prefix: '/emissions' })
     '/:shipmentId/request',
     AuthController.authMiddleware,
     ConsumeFootprintController.initiateFileTransfer
+  )
+  .get(
+    'Get Footprint data',
+    '/:shipmentId',
+    AuthController.authMiddleware,
+    ConsumeFootprintController.getData
   );
-
-export const pactCompliantRouter = new KoaRouter().get(
-  'Get Footprint data',
-  '/footprints/:shipmentId',
-  AuthController.authMiddleware,
-  ConsumeFootprintController.getData
-);

--- a/src/participants/usecases/initiate-file-transfer.ts
+++ b/src/participants/usecases/initiate-file-transfer.ts
@@ -81,22 +81,30 @@ export class InitiateFileTransferUsecase {
     }
   }
 
-  private async startContractNegotiation(provider, shipmentId) {
-    const contractOffer = await this.getContractOffer(shipmentId, provider);
+  private async startContractNegotiation(
+    provider: Omit<ParticipantType, 'connection'>,
+    shipmentId: string
+  ) {
+    const contractOffer = await this.getContractOffer(
+      shipmentId,
+      provider.connector_data.addresses.protocol
+    );
 
     const result = await this.negotiateContract(contractOffer, provider);
 
     return result;
   }
 
-  private async getContractOffer(
+  async getContractOffer(
     shipmentId: string,
-    provider: Omit<ParticipantType, 'connection'>
+    connectorProtocolAddress?: string
   ) {
     const assetFilter = builder.filter('asset:prop:id', shipmentId);
 
     const catalogs = await this.edcClient.listCatalog({
-      providerUrl: provider.connector_data.addresses.protocol + '/data',
+      providerUrl: connectorProtocolAddress
+        ? `${connectorProtocolAddress}/data`
+        : `${this.edcClient.edcClientContext.protocol}/data`,
       querySpec: assetFilter,
     });
 

--- a/src/participants/usecases/provide-footprint.ts
+++ b/src/participants/usecases/provide-footprint.ts
@@ -12,4 +12,12 @@ export class ProvideFootprintUsecase {
       name: asset.properties['asset:prop:name'],
     }));
   }
+
+  async delete(contractId: string) {
+    try {
+      await this.edcClient.deleteContractDefinition(contractId);
+    } catch (error) {
+      throw error;
+    }
+  }
 }


### PR DESCRIPTION
## Description
This PR resolves #67. 
More context can be found in this ticket:https://github.com/orgs/smart-freight-center/projects/1?pane=issue&itemId=26575417

### How to test it
1. Share a shipment making a `POST` request to **/emissions**
2. Verify that it was properly 'shared' with a `GET` request to **/emissions/sent**
3. Unshare it with a `DELETE` to **request/emissions/sent**

## Learnings
- It is possible to request to see your own catalog.
```
curl -d '{
        "providerUrl": "http://{{myConnectorControlIdsProtocolAddress}}"

        }' -H 'content-type: application/json' {{myConnectorControlPlane}}/api/v1/data/catalog/request
```
- It is not possible to delete a contract agreement
- Cancelling the contract negotiation doesn't have any effect on the sharing process later on. Check this [link](https://app.swaggerhub.com/apis/eclipse-edc-bot/management-api/0.0.1-SNAPSHOT#/Contract%20Negotiation/cancelNegotiation)
- Deleting an asset is only possible if it's not linked to a contract agreement. In our case, it couldn't do the trick
- Deleting a contract definition is possible even if it's linked to other entities (for instance: policy definitions & contract offers) and will make the transfer process fail => that was the chosen reasoning

