### PR TITLE
fix: change path to keyName in s3 data address schema

### DIFF
--- a/src/participants/clients/data-source-service.ts
+++ b/src/participants/clients/data-source-service.ts
@@ -37,7 +37,7 @@ export class DataSourceService {
 
   private static async fetchDataOnS3(input: ShareFootprintInput) {
     const command = new GetObjectCommand({
-      Key: input.dataLocation.path,
+      Key: input.dataLocation.keyName,
       Bucket: input.dataLocation.bucketName,
     });
 

--- a/src/participants/validators/share-footprint-schema.ts
+++ b/src/participants/validators/share-footprint-schema.ts
@@ -22,7 +22,7 @@ const s3Schema = {
     name: 'required|min:1',
     bucketName: 'required|min:1|string',
     region: 'required|min:1',
-    path: 'min:4|required',
+    keyName: 'min:4|required',
   },
 };
 


### PR DESCRIPTION
## Description
the connector accepts keyName as a parameter instead of path. this PR changes the input schema so that it reflects that.
