### PR TITLE
fix: specify aws region for pulling data from s3 by the backend

### DIFF
--- a/src/participants/clients/data-source-service.ts
+++ b/src/participants/clients/data-source-service.ts
@@ -2,7 +2,7 @@ import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
 import axios from 'axios';
 import { ShareFootprintInput } from 'entities';
 import { CouldntFetchDataInSource } from 'utils/error';
-import { AWS_ACCESS_ID, AWS_REGION, AWS_SECRET } from 'utils/settings';
+import { AWS_ACCESS_ID, AWS_SECRET, CLIENT_CONFIG } from 'utils/settings';
 
 export class DataSourceService {
   public static async fetchFootprintData(input: ShareFootprintInput) {
@@ -42,7 +42,7 @@ export class DataSourceService {
     });
 
     const s3Client = new S3Client({
-      region: AWS_REGION,
+      region: CLIENT_CONFIG.region,
       credentials: {
         accessKeyId: AWS_ACCESS_ID || '',
         secretAccessKey: AWS_SECRET || '',


### PR DESCRIPTION
## Description
This PR resolves an issue where the region of the S3 bucket containing the participant's configuration file is different from the S3 bucket's region where the data resides.

### How to test it
can be tested by creating an S3 bucket in a region different from `eu-west-1` ( where the S3 bucket containing the participant's configuration is ) and using it as a data source.

