### PR TITLE
fix: update connector config to work with new version

### DIFF
--- a/conf/consumer-connector.config/addresses.json
+++ b/conf/consumer-connector.config/addresses.json
@@ -1,14 +1,11 @@
 {
-  "id": "urn:connector:consumer",
-  "title": "consumer.edc.think-it.io",
-  "catalogId": "default",
-  "description": "The consumer connector for the EDC manager demo",
-  "region": "eu-west-1",
+  "uid": "1",
+  "name": "consumer.edc.think-it.io",
   "addresses": {
-    "default": "http://localhost:19191",
-    "control": "http://localhost:19192",
-    "data": "http://localhost:19193",
-    "ids": "http://consumer-connector:9194",
-    "public": "http://localhost:19291"
+    "default": "http://localhost:19191/api",
+    "management": "http://localhost:19193/management",
+    "protocol": "http://consumer-connector:9194/protocol",
+    "public": "http://localhost:19291/public",
+    "control": "http://localhost:19292/control"
   }
 }

--- a/conf/consumer-connector.config/configuration.properties
+++ b/conf/consumer-connector.config/configuration.properties
@@ -1,5 +1,5 @@
-edc.ids.id=urn:connector:consumer
-ids.webhook.address=http://consumer-connector:9194
+edc.participant.id=consumer
+edc.dsp.callback.address=http://consumer-connector:9194/protocol
 
 web.http.port=9191
 web.http.path=/api
@@ -8,14 +8,14 @@ web.http.control.port=9192
 web.http.control.path=/control
 
 web.http.management.port=9193
-web.http.management.path=/api/v1/data
+web.http.management.path=/management
 
 web.http.protocol.port=9194
-web.http.protocol.path=/api/v1/ids
+web.http.protocol.path=/protocol
 
 edc.api.control.auth.apikey.value=123456
 
-edc.receiver.http.endpoint=http://host.docker.internal:4000/receiver/urn:connector:consumer/callback
+edc.receiver.http.endpoint=http://host.docker.internal:19999
 
 edc.public.key.alias=public-key
 
@@ -28,4 +28,13 @@ edc.transfer.proxy.token.verifier.publickey.alias=sync-transfer-public-key
 web.http.public.port=9291
 web.http.public.path=/public
 
-edc.dataplane.token.validation.endpoint=http://provider-connector:9192/control/token
+edc.dataplane.token.validation.endpoint=http://consumer-connector:9192/control/token
+
+edc.negotiation.consumer.send.retry.limit=1
+edc.negotiation.consumer.send.retry.base-delay.ms=10
+edc.negotiation.provider.send.retry.limit=1
+edc.negotiation.provider.send.retry.base-delay.ms=10
+edc.negotiation.state-machine.iteration-wait-millis=100
+edc.transfer.send.retry.limit=1
+edc.transfer.send.retry.base-delay.ms=10
+edc.transfer.state-machine.iteration-wait-millis=10

--- a/conf/provider-connector.config/addresses.json
+++ b/conf/provider-connector.config/addresses.json
@@ -1,14 +1,11 @@
 {
-  "id": "urn:connector:provider",
-  "title": "provider.edc.think-it.io",
-  "catalogId": "default",
-  "description": "The provider connector for the EDC manager demo",
-  "region": "eu-west-1",
+  "uid": "2",
+  "name": "provider.edc.think-it.io",
   "addresses": {
-    "default": "http://localhost:29191",
-    "control": "http://localhost:29192",
-    "data": "http://localhost:29193",
-    "ids": "http://provider-connector:9194",
-    "public": "http://localhost:29291"
+    "default": "http://localhost:29191/api",
+    "management": "http://localhost:29193/management",
+    "protocol": "http://provider-connector:9194/protocol",
+    "public": "http://localhost:29291/public",
+    "control": "http://localhost:29292/control"
   }
 }

--- a/conf/provider-connector.config/configuration.properties
+++ b/conf/provider-connector.config/configuration.properties
@@ -1,5 +1,5 @@
-edc.ids.id=urn:connector:provider
-ids.webhook.address=http://provider-connector:9194
+edc.participant.id=provider
+edc.dsp.callback.address=http://provider-connector:9194/protocol
 
 web.http.port=9191
 web.http.path=/api
@@ -8,12 +8,14 @@ web.http.control.port=9192
 web.http.control.path=/control
 
 web.http.management.port=9193
-web.http.management.path=/api/v1/data
+web.http.management.path=/management
 
 web.http.protocol.port=9194
-web.http.protocol.path=/api/v1/ids
+web.http.protocol.path=/protocol
 
-edc.receiver.http.endpoint=http://host.docker.internal:4000/receiver/urn:connector:provider/callback
+edc.api.control.auth.apikey.value=123456
+
+edc.receiver.http.endpoint=http://host.docker.internal:19999
 
 edc.public.key.alias=public-key
 
@@ -27,3 +29,12 @@ web.http.public.port=9291
 web.http.public.path=/public
 
 edc.dataplane.token.validation.endpoint=http://provider-connector:9192/control/token
+
+edc.negotiation.consumer.send.retry.limit=1
+edc.negotiation.consumer.send.retry.base-delay.ms=10
+edc.negotiation.provider.send.retry.limit=1
+edc.negotiation.provider.send.retry.base-delay.ms=10
+edc.negotiation.state-machine.iteration-wait-millis=100
+edc.transfer.send.retry.limit=1
+edc.transfer.send.retry.base-delay.ms=10
+edc.transfer.state-machine.iteration-wait-millis=10


### PR DESCRIPTION
## Description
Found a tiny bug in the configuration updates we did. This PR fixes it. 


### How to test it
Run the Postman collection from [tractusx-edc](https://github.com/eclipse-tractusx/tractusx-edc) and try to hit any of the endpoints. It should work now.

Resolves #153 
