### PR TITLE
feat: improve metadata stored in connector

### DIFF
--- a/src/core/services/sfc-dataspace/edc-client.ts
+++ b/src/core/services/sfc-dataspace/edc-client.ts
@@ -45,8 +45,8 @@ export class EdcClient implements IEdcClient {
       this.edcClientContext
     );
   }
-  async listAssets() {
-    return this.edcConnectorClient.management.assets.queryAll();
+  async listAssets(query?: QuerySpec) {
+    return this.edcConnectorClient.management.assets.queryAll(query);
   }
 
   async createPolicy(input: PolicyDefinitionInput) {

--- a/src/core/services/sfc-dataspace/interfaces.ts
+++ b/src/core/services/sfc-dataspace/interfaces.ts
@@ -1,4 +1,5 @@
 import {
+  Asset,
   AssetInput,
   Catalog,
   CatalogRequest,
@@ -18,7 +19,7 @@ import {
 
 export interface IEdcClient {
   deleteAsset: (assetId: string) => Promise<void>;
-  listAssets: () => Promise<unknown>;
+  listAssets: (query?: QuerySpec) => Promise<Asset[]>;
   createPolicy: (input: PolicyDefinitionInput) => Promise<CreateResult>;
   createAsset: (input: AssetInput) => Promise<CreateResult>;
   deletePolicy: (policyId: string) => Promise<void>;

--- a/src/core/usecases/__tests__/share-footprint.unit.test.ts
+++ b/src/core/usecases/__tests__/share-footprint.unit.test.ts
@@ -22,6 +22,16 @@ const shareFootprint = new ShareFootprintUsecase(
   mockSfcAPI
 );
 
+const mockInput = {
+  month: 10,
+  year: 2023,
+  companyId: 'consumer-id',
+  dateCreated: '2020-01-01',
+  shipmentId: 'shipment1',
+  type: 's3',
+  dataLocation: {},
+};
+
 describe('ShareFootprintUsecase', () => {
   describe('Input validation', () => {
     it('should throw an error when the input is invalid', async () => {
@@ -31,22 +41,17 @@ describe('ShareFootprintUsecase', () => {
 
       errors.should.be.eql({
         companyId: ['This field is required'],
-        dateCreated: ['This field is required'],
         shipmentId: ['This field is required'],
         type: ['This field is required'],
         dataLocation: ['This field is required'],
+        year: ['This field is required'],
+        month: ['This field is required'],
       });
     });
 
     it('AWS S3 fields should be required when type=s3', async () => {
       const { errors } = await expect(
-        shareFootprint.execute('auth-code', {
-          companyId: 'consumer-id',
-          dateCreated: '2020-01-01',
-          shipmentId: 'shipment1',
-          type: 's3',
-          dataLocation: {},
-        })
+        shareFootprint.execute('auth-code', mockInput)
       ).to.be.rejectedWith(DataValidationError);
 
       errors.should.be.eql({
@@ -62,9 +67,7 @@ describe('ShareFootprintUsecase', () => {
     it('Azure Blob fields should be required when type=azure', async () => {
       const { errors } = await expect(
         shareFootprint.execute('auth-code', {
-          companyId: 'consumer-id',
-          dateCreated: '2020-01-01',
-          shipmentId: 'shipment1',
+          ...mockInput,
           type: 'azure',
           dataLocation: {},
         })
@@ -82,9 +85,7 @@ describe('ShareFootprintUsecase', () => {
     it('HTTP  fields should be required when type=http', async () => {
       const { errors } = await expect(
         shareFootprint.execute('auth-code', {
-          companyId: 'consumer-id',
-          dateCreated: '2020-01-01',
-          shipmentId: 'shipment1',
+          ...mockInput,
           type: 'http',
           dataLocation: {},
         })
@@ -109,10 +110,8 @@ describe('ShareFootprintUsecase', () => {
         mockDataSourceFetcher.fetchFootprintData.returns(Promise.resolve(''));
 
         const validInput = {
-          companyId: 'consumer-id',
-          dateCreated: '2020-01-01',
-          shipmentId: 'shipment1',
-          type: 'http' as const,
+          ...mockInput,
+          type: 'http',
           dataLocation: {
             name: 'ShipmentId-1',
             baseUrl: 'http://example.com/footprints.csv',
@@ -132,9 +131,7 @@ describe('ShareFootprintUsecase', () => {
         );
 
         const validInput = {
-          companyId: 'consumer-id',
-          dateCreated: '2020-01-01',
-          shipmentId: 'shipmentid1',
+          ...mockInput,
           type: 'http' as const,
           dataLocation: {
             name: 'ShipmentId-1',
@@ -168,9 +165,7 @@ describe('ShareFootprintUsecase', () => {
         );
 
         const validInput = {
-          companyId: 'consumer-id',
-          dateCreated: '2020-01-01',
-          shipmentId: 'shipment1',
+          ...mockInput,
           type: 'http' as const,
           dataLocation: {
             name: 'ShipmentId-1',
@@ -237,9 +232,7 @@ describe('ShareFootprintUsecase', () => {
         );
 
         const validInput = {
-          companyId: 'consumer-id',
-          dateCreated: '2020-01-01',
-          shipmentId: 'shipmentid1',
+          ...mockInput,
           type: 'http' as const,
           dataLocation: {
             name: 'ShipmentId-1',

--- a/src/core/usecases/interfaces.ts
+++ b/src/core/usecases/interfaces.ts
@@ -1,12 +1,13 @@
 import { ShareFootprintInput } from 'entities';
 import { EmissionDataModel, Participant } from '../types';
 
+export type ShareDataspaceAssetInput = ShareFootprintInput & {
+  provider: Participant;
+  consumer: Omit<Participant, 'connection'>;
+  numberOfRows: number;
+};
 export interface ISfcDataSpace {
-  shareAsset(
-    provider: Participant,
-    consumer: Omit<Participant, 'connection'>,
-    input: ShareFootprintInput
-  ): Promise<object>;
+  shareAsset(input: ShareDataspaceAssetInput): Promise<object>;
   unshareFootprint(shipmentId: string, companyId: string): Promise<void>;
   fetchCarbonFootprint(input): Promise<EmissionDataModel[]>;
 

--- a/src/core/usecases/share-footprint.ts
+++ b/src/core/usecases/share-footprint.ts
@@ -31,14 +31,20 @@ export class ShareFootprintUsecase {
       validatedInput
     );
 
-    await this.verifyDataModel(validatedInput.shipmentId, rawData);
+    const data = await this.verifyDataModel(validatedInput.shipmentId, rawData);
     const sfcConnection = await this.sfcAPI.createConnection(
       authorization || ''
     );
     const consumer = await sfcConnection.getCompany(validatedInput.companyId);
     const provider = await sfcConnection.getMyProfile();
 
-    return this.sfcDataSpace.shareAsset(provider, consumer, validatedInput);
+    const numberOfRows = data.length;
+    return this.sfcDataSpace.shareAsset({
+      ...validatedInput,
+      provider,
+      consumer,
+      numberOfRows,
+    });
   }
 
   private validateInput(input: Partial<ShareFootprintInput>) {

--- a/src/core/validators/share-footprint-schema.ts
+++ b/src/core/validators/share-footprint-schema.ts
@@ -52,8 +52,9 @@ const joiAzureSchema = joi.object({
 });
 const sharedSchema = joi.object({
   shipmentId: joi.string().required(),
+  month: joi.number().integer().greater(0).less(13).required(),
+  year: joi.number().required(),
   companyId: joi.string().required(),
-  dateCreated: joi.string().required(),
   contentType: joi.string().valid('application/json', 'text/csv'),
   type: joi.string().required().lowercase().valid('azure', 'http', 's3'),
   dataLocation: joi.object().required(),

--- a/src/entities/footprint.ts
+++ b/src/entities/footprint.ts
@@ -2,11 +2,12 @@ import { DataAddress } from '@think-it-labs/edc-connector-client';
 
 export type ShareFootprintInput = {
   shipmentId: string;
+  month: number;
+  year: number;
   companyId: string;
   dateCreated?: string;
-  type: 'azure' | 'http' | 's3';
+  type: 'azure' | 'http' | 's3' | string;
   dataLocation: Omit<DataAddress, 'contentType'>;
-  contentType?: string;
 };
 
 export interface ListCatalogInput {

--- a/src/utils/edc-builder.ts
+++ b/src/utils/edc-builder.ts
@@ -1,4 +1,3 @@
-import dateAndTime from 'date-and-time';
 import { v4 } from 'uuid';
 
 import {
@@ -22,12 +21,14 @@ function randomUid() {
   return v4();
 }
 
-export function assetInput(
-  dataInput: ShareFootprintInput,
-  providerClientId: string,
-  sharedWith: string
-): AssetInput {
-  const { shipmentId, dataLocation, type, dateCreated } = dataInput;
+type ShareAssetInput = ShareFootprintInput & {
+  providerClientId: string;
+  sharedWith: string;
+  numberOfRows: number;
+};
+
+export function assetInput(dataInput: ShareAssetInput): AssetInput {
+  const { month, year, dataLocation, type } = dataInput;
 
   const now = new Date();
 
@@ -37,15 +38,14 @@ export function assetInput(
     azure: 'AzureStorage',
   };
 
-  const defaultVersion = dateAndTime.format(now, 'YYYY-MM-DD');
-  const createdFilter = dateCreated || defaultVersion;
-
   return {
-    '@id': `${shipmentId}-${sharedWith}__${+now}_${createdFilter}`,
+    '@id': `${month}-${year}_$${+now}`,
     properties: {
-      name: shipmentId,
-      owner: providerClientId,
-      sharedWith,
+      month: dataInput.month,
+      year: dataInput.year,
+      owner: dataInput.providerClientId,
+      sharedWith: dataInput.sharedWith,
+      numberOfRows: dataInput.numberOfRows,
     },
     privateProperties: {},
     dataAddress: {
@@ -102,9 +102,9 @@ export function contractDefinition(
     contractPolicyId: policyId,
     assetsSelector: [
       {
-        operandLeft: 'asset:prop:id',
+        operandLeft: 'https://w3id.org/edc/v0.0.1/ns/id',
         operator: '=',
-        operandRight: 'new-asset-id',
+        operandRight: assetId,
       },
     ],
   };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -46,7 +46,6 @@ export const sleep = (ms: number): Promise<void> => {
 };
 
 export const handleErrors = (context: Context, error: Error) => {
-  console.log(error);
   if (error instanceof EdcConnectorClientError) {
     context.set('Content-type', 'application/json');
     switch (error.type) {


### PR DESCRIPTION

## Description
- updates the object stored in connector to use the latest API data
- adds month and year to the inputs by the participants
- updates unit tests to reflect changes
- improves the way we verify that an asset exists by using the new connector API

### How to test it
- Share a carbon footprint data using the API 
- Whne you retrieve the assets using the trautusx docs, you should see the extra properties added on this PR



### Screenshots



## Approach
The main idea here is that since we intend to save data by month, it makes sense to be able to query/fetch that data by month. Adding the month and year property makes this possible


Closes #161 