### PR TITLE
Feat data provider can view emissions they had shared

### DIFF
--- a/src/api/controllers/provide-footprint.ts
+++ b/src/api/controllers/provide-footprint.ts
@@ -48,7 +48,9 @@ export class ProvideFootPrintController {
 
   static async getSharedFootprints(context: RouterContext) {
     try {
-      const assets = await provideFootprintUsecase.execute();
+      const assets = await provideFootprintUsecase.execute(
+        context.headers.authorization as string
+      );
       context.body = assets;
       context.status = 200;
     } catch (error) {

--- a/src/core/services/sfc-dataspace/__tests__/share-asset.unit.test.ts
+++ b/src/core/services/sfc-dataspace/__tests__/share-asset.unit.test.ts
@@ -82,16 +82,16 @@ describe('SfcDataspace', () => {
       mockEdcClient.createContractDefinitions.reset();
 
       mockEdcClient.createAsset.returns(
-        Promise.resolve({ id: 'new-asset-id', createdAt: 50 })
+        Promise.resolve({ id: 'new-asset-id', createdAt: 50 } as any)
       );
       mockEdcClient.createPolicy.returns(
-        Promise.resolve({ id: 'new-policy-id', createdAt: 50 })
+        Promise.resolve({ id: 'new-policy-id', createdAt: 50 } as any)
       );
       mockEdcClient.createContractDefinitions.returns(
         Promise.resolve({
           id: 'new-contract-definition',
           createdAt: 60,
-        })
+        } as any)
       );
     });
 

--- a/src/core/services/sfc-dataspace/interfaces.ts
+++ b/src/core/services/sfc-dataspace/interfaces.ts
@@ -9,7 +9,7 @@ import {
   ContractNegotiation,
   ContractNegotiationRequest,
   ContractNegotiationState,
-  CreateResult,
+  IdResponse,
   PolicyDefinition,
   PolicyDefinitionInput,
   QuerySpec,
@@ -20,13 +20,13 @@ import {
 export interface IEdcClient {
   deleteAsset: (assetId: string) => Promise<void>;
   listAssets: (query?: QuerySpec) => Promise<Asset[]>;
-  createPolicy: (input: PolicyDefinitionInput) => Promise<CreateResult>;
-  createAsset: (input: AssetInput) => Promise<CreateResult>;
+  createPolicy: (input: PolicyDefinitionInput) => Promise<IdResponse>;
+  createAsset: (input: AssetInput) => Promise<IdResponse>;
   deletePolicy: (policyId: string) => Promise<void>;
   listPolicy: () => Promise<PolicyDefinition[]>;
   createContractDefinitions: (
     input: ContractDefinitionInput
-  ) => Promise<CreateResult>;
+  ) => Promise<IdResponse>;
 
   deleteContractDefinition: (contractDefinitionId: string) => Promise<void>;
   queryAllContractDefinitions: (
@@ -36,7 +36,7 @@ export interface IEdcClient {
   queryAllPolicies: (input) => Promise<PolicyDefinition[]>;
   starContracttNegotiation: (
     input: ContractNegotiationRequest
-  ) => Promise<CreateResult>;
+  ) => Promise<IdResponse>;
 
   getContractNegotiationResponse: (
     contracNegotiationId: string
@@ -48,5 +48,5 @@ export interface IEdcClient {
   ) => Promise<ContractAgreement>;
   queryAllAgreements: (query?: QuerySpec) => Promise<ContractAgreement[]>;
   getNegotiationState: (input: string) => Promise<ContractNegotiationState>;
-  initiateTransfer: (input: TransferProcessInput) => Promise<CreateResult>;
+  initiateTransfer: (input: TransferProcessInput) => Promise<IdResponse>;
 }

--- a/src/core/usecases/__tests__/stubs.ts
+++ b/src/core/usecases/__tests__/stubs.ts
@@ -15,6 +15,7 @@ export const mockSfcDataSpace: SinonStubbedInstance<ISfcDataSpace> = {
   unshareFootprint: sinon.stub(),
   fetchCarbonFootprint: sinon.stub(),
   startTransferProcess: sinon.stub(),
+  fetchFootprintsMetaData: sinon.stub(),
 };
 
 export const sfcConnectionStub = () => {

--- a/src/core/usecases/index.ts
+++ b/src/core/usecases/index.ts
@@ -17,7 +17,10 @@ import { DeleteFootprintUsecase } from './delete-fooprint';
 import { InitiateBatchRequestUsecase } from './initiate-batch-request';
 import { AuthTokenCallbackUsecase } from './auth-token-callback';
 
-export const provideFootprintUsecase = new ListSharedAssetsUsecsase(edcClient);
+export const provideFootprintUsecase = new ListSharedAssetsUsecsase(
+  sfcDataSpace,
+  sfcAPI
+);
 export const deleteFootprintUsecase = new DeleteFootprintUsecase(sfcDataSpace);
 export const shareFootprintUsecase = new ShareFootprintUsecase(
   sfcDataSpace,

--- a/src/core/usecases/interfaces.ts
+++ b/src/core/usecases/interfaces.ts
@@ -6,10 +6,20 @@ export type ShareDataspaceAssetInput = ShareFootprintInput & {
   consumer: Omit<Participant, 'connection'>;
   numberOfRows: number;
 };
+
+export type FootprintMetaData = {
+  owner: string;
+  numberOfRows: number | string;
+  month: number;
+  sharedWith: number;
+  year: number;
+  id: string;
+};
 export interface ISfcDataSpace {
   shareAsset(input: ShareDataspaceAssetInput): Promise<object>;
   unshareFootprint(shipmentId: string, companyId: string): Promise<void>;
   fetchCarbonFootprint(input): Promise<EmissionDataModel[]>;
+  fetchFootprintsMetaData(provider: Participant): Promise<FootprintMetaData[]>;
 
   startTransferProcess(
     provider: Omit<Participant, 'connection'>,

--- a/src/core/usecases/list-shared-assets.ts
+++ b/src/core/usecases/list-shared-assets.ts
@@ -1,29 +1,12 @@
-import { EdcClient } from '../services/sfc-dataspace/edc-client';
+import { ISFCAPI, ISfcDataSpace } from './interfaces';
 export class ListSharedAssetsUsecsase {
-  constructor(private edcClient: EdcClient) {}
+  constructor(private sfcDataspace: ISfcDataSpace, private sfcUnit: ISFCAPI) {}
 
-  async execute() {
-    const sharedContracts = await this.edcClient.queryAllContractDefinitions();
-    return sharedContracts.map((contract) => {
-      const firstDelimiter = contract.id.indexOf('__');
-      const substring = contract.id.slice(0, firstDelimiter);
-      const lastDateDelimiter = contract.id.lastIndexOf('_');
-      const sharingDate = contract.id.slice(
-        firstDelimiter + 2,
-        lastDateDelimiter
-      );
-      const sharedWithIdx = substring.lastIndexOf('-');
-      const sharedWith = substring.slice(sharedWithIdx + 1);
+  async execute(authorization: string) {
+    const provider = await this.sfcUnit
+      .createConnection(authorization)
+      .getMyProfile();
 
-      const shipmentAndConsumer = contract.id.slice(0, firstDelimiter);
-      const lastDashIdx = shipmentAndConsumer.lastIndexOf('-');
-
-      return {
-        id: shipmentAndConsumer,
-        shipmentId: shipmentAndConsumer.slice(0, lastDashIdx),
-        sharedWith,
-        sharingDate: new Date(parseInt(sharingDate)).toLocaleString('en-US'),
-      };
-    });
+    return this.sfcDataspace.fetchFootprintsMetaData(provider);
   }
 }

--- a/src/utils/edc-builder.ts
+++ b/src/utils/edc-builder.ts
@@ -45,6 +45,7 @@ export function assetInput(dataInput: ShareAssetInput): AssetInput {
       year: dataInput.year,
       owner: dataInput.providerClientId,
       sharedWith: dataInput.sharedWith,
+      deleted: 'false',
       numberOfRows: dataInput.numberOfRows,
     },
     privateProperties: {},
@@ -111,12 +112,12 @@ export function contractDefinition(
 }
 
 export function filter(
-  operandLeft,
-  operandRight,
-  operator = '='
+  operandLeft: string,
+  operator = '=',
+  operandRight: string | number | boolean
 ): CriterionInput {
   return {
-    operandLeft: operandLeft,
+    operandLeft: `https://w3id.org/edc/v0.0.1/ns/${operandLeft}`,
     operandRight: operandRight,
     operator: operator,
   };

--- a/src/utils/errors/index.ts
+++ b/src/utils/errors/index.ts
@@ -44,7 +44,8 @@ export class ParticipantNotFound extends NotFound {
   message = 'Participant not found';
 }
 export class ShipmentAlreadyShared extends DataConflict {
-  message = 'This shipment has already been shared with that company.';
+  message =
+    'The carbon footprint for that month has already been shared with that company.';
   name = 'shipment_already_shared';
 }
 export class TransferInitiationFailed {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5516,9 +5516,9 @@ undefsafe@^2.0.5:
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
 undici@^5.21.2:
-  version "5.25.4"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.25.4.tgz#7d8ef81d94f84cd384986271e5e5599b6dff4296"
-  integrity sha512-450yJxT29qKMf3aoudzFpIciqpx6Pji3hEWaXqXmanbXF58LTAGCKxcJjxMXWu3iG+Mudgo3ZUfDB6YDFd/dAw==
+  version "5.26.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.26.0.tgz#e3ea0843574b7abd90fa3240954ee82bf9c8fb3e"
+  integrity sha512-MLqGMyaJk2ubSl7FrmWuV7ZOsYWmdF7gcBHDRxm4AR8NoodQhgy3vO/D1god79HoetxR0uAeVNB65yj2lNRQnQ==
   dependencies:
     "@fastify/busboy" "^2.0.0"
 


### PR DESCRIPTION
## Description

This PR modifies the endpoint that retreives the emissions that a user has previously shared and add the new  metadatas from  #167 to the response

### How to test it
- Share an a carbon footprint
- Retrieve the emissions that you have sent by hitting `/emissions/sent`


### Screenshots
<img width="1008" alt="Screenshot 2023-10-12 at 11 32 28" src="https://github.com/smart-freight-center/sfc-backend/assets/38565349/e26314cf-58e3-42e7-9734-175c80e2ff42">


## Approach
- I leveraged the [requestAsset](https://app.swaggerhub.com/apis/eclipse-edc-bot/management-api/0.3.0#/Asset/requestAssets_1) endpoint to get assets that users have shared. 
- While doing this though, I noticed that the @think-it/edc-connector-client was giving me the wrong response. The response from the APi and that of the client were different. Thus, I decided to use axios to make the call to the API directly(see the edc-client). 

**Response from API**
<img width="1059" alt="Screenshot 2023-10-11 at 16 00 20" src="https://github.com/smart-freight-center/sfc-backend/assets/38565349/c980f39f-d2d0-4afb-b58d-bdfb528ddcbf">


**Response from Client**

<img width="1052" alt="Screenshot 2023-10-11 at 15 59 55" src="https://github.com/smart-freight-center/sfc-backend/assets/38565349/f2b3d607-fc28-4aab-8029-63d7a4269672">


I would say we use this temporary walkaround while looking for a way to make the client work.

Resolves #162 
