### PR TITLE
feat: updates code that unshares assets

### DIFF
--- a/src/api/routes/emissions.ts
+++ b/src/api/routes/emissions.ts
@@ -20,7 +20,7 @@ export const emissionRoutes = new KoaRouter({ prefix: '/emissions' })
   )
   .delete(
     'Revoke access to a shipment',
-    '/sent/:shipmentId',
+    '/sent',
     ProvideFootPrintController.unshareFootprint
   )
 

--- a/src/core/__tests__/mocks.ts
+++ b/src/core/__tests__/mocks.ts
@@ -1,0 +1,46 @@
+import { Participant } from 'core/types';
+
+export const mockConsumerConnector = {
+  default: 'http://consumer:29191/api',
+  validation: 'http://consumer:29292',
+  management: 'http://consumer:29193/api/v1/data',
+  protocol: 'http://provider-connector:9194/api/v1/ids',
+  dataplane: 'http://consumer:29195',
+  public: 'http://consumer:29291/public',
+  control: 'http://consumer:29292/control',
+};
+
+export const mockProviderConnector = {
+  default: 'http://provider-host:29191/api',
+  validation: 'http://provider-host:29292',
+  management: 'http://provider-host:29193/api/v1/data',
+  protocol: 'http://provider-connector:9194/api/v1/ids',
+  dataplane: 'http://provider-host:29195',
+  public: 'http://provider-host:29291/public',
+  control: 'http://provider-host:29292/control',
+};
+export const mockProvider: Participant = {
+  company_name: 'data-provider',
+  client_id: 'provider',
+  company_BNP: 'provider-bpn',
+  role: 'shipper',
+  connection: ['data-consuer'],
+  public_key: 'provider-pb',
+  connector_data: {
+    id: 'urn:connector:provider',
+    addresses: mockProviderConnector,
+  },
+};
+
+export const mockConsumer: Participant = {
+  company_name: 'data-consumer',
+  client_id: 'consumer',
+  company_BNP: 'consumer-bpn',
+  role: 'lsp',
+  connection: ['data-provider'],
+  public_key: 'consumer-pb',
+  connector_data: {
+    id: '',
+    addresses: mockConsumerConnector,
+  },
+};

--- a/src/core/services/sfc-dataspace/edc-client.ts
+++ b/src/core/services/sfc-dataspace/edc-client.ts
@@ -53,7 +53,6 @@ export class EdcClient implements IEdcClient {
     });
 
     return res.data;
-    // return this.edcConnectorClient.management.assets.queryAll(query);
   }
 
   async createPolicy(input: PolicyDefinitionInput) {
@@ -95,14 +94,12 @@ export class EdcClient implements IEdcClient {
     return this.edcConnectorClient.management.policyDefinitions.queryAll(input);
   }
   async starContracttNegotiation(input: ContractNegotiationRequest) {
-    // return this.edcConnectorClient.management.initiateContractNegotiation(
     return this.edcConnectorClient.management.contractNegotiations.initiate(
       input
     );
   }
   async getContractNegotiationResponse(contracNegotiationId: string) {
     return this.edcConnectorClient.management.contractNegotiations.get(
-      // return this.edcConnectorClient.management.getNegotiation(
       contracNegotiationId
     );
   }

--- a/src/core/usecases/__tests__/delete-footprint.unit.test.ts
+++ b/src/core/usecases/__tests__/delete-footprint.unit.test.ts
@@ -1,0 +1,113 @@
+import { SfcDataSpace } from 'core/services/sfc-dataspace/sfc-dataspace';
+import { DeleteFootprintUsecase } from '../delete-fooprint';
+import { sfcConnectionStub } from './stubs';
+import { mockEdcClient } from 'core/services/sfc-dataspace/__tests__/stubs';
+import { expect } from 'chai';
+import { DataValidationError } from 'utils/errors/base-errors';
+import { ShipmentForMonthNotFound } from 'utils/errors';
+import { mockProvider } from 'core/__tests__/mocks';
+import { Asset } from '@think-it-labs/edc-connector-client';
+
+const { mockSfcAPI, mockSFCAPIConnection } = sfcConnectionStub();
+
+const mockSfcDataspace = new SfcDataSpace(mockEdcClient);
+
+const deleteFootprintUsecase = new DeleteFootprintUsecase(
+  mockSfcAPI,
+  mockSfcDataspace
+);
+
+describe('Delete Footprint Tests', () => {
+  beforeEach(() => {
+    mockEdcClient.listAssets.reset();
+  });
+  it('should throw error when the values are wrong', async () => {
+    const { errors } = await expect(
+      deleteFootprintUsecase.execute('provider-auth', {
+        month: '19',
+        year: 'invalid-year',
+        companyId: 'consumer-id',
+      })
+    ).to.be.rejectedWith(DataValidationError);
+    errors.should.be.eql({
+      year: ['This field must be a number'],
+      month: ['This field must be less than 13'],
+    });
+  });
+
+  it('should throw error when the the asset does not exists', async () => {
+    mockSFCAPIConnection.getMyProfile.returns(
+      Promise.resolve({ ...mockProvider, client_id: 'provider-client' })
+    );
+    mockEdcClient.listAssets.returns(Promise.resolve([]));
+    await expect(
+      deleteFootprintUsecase.execute('provider-auth', {
+        month: '8',
+        year: '2021',
+        companyId: 'consumer-id',
+      })
+    ).to.be.rejectedWith(ShipmentForMonthNotFound);
+  });
+
+  it('should delete asset that is found', async () => {
+    const validInput = {
+      month: '8',
+      year: '2021',
+      companyId: 'consumer-id',
+    };
+    mockSFCAPIConnection.getMyProfile.returns(
+      Promise.resolve({ ...mockProvider, client_id: 'provider-client' })
+    );
+    mockEdcClient.listAssets.returns(
+      Promise.resolve([
+        {
+          '@id': 'sample-asset-id',
+          '@type': 'edc:Asset',
+          'edc:properties': {
+            'edc:owner': 'provider-client',
+            'edc:numberOfRows': 3.0,
+            'edc:month': 12.0,
+            'edc:sharedWith': validInput.companyId,
+          },
+          'edc:dataAddress': {},
+        },
+      ] as unknown[] as Asset[])
+    );
+    await expect(
+      deleteFootprintUsecase.execute('provider-auth', {
+        month: '8',
+        year: '2021',
+        companyId: 'consumer-id',
+      })
+    ).to.not.be.rejected;
+
+    mockEdcClient.deleteAsset.should.have.been.calledOnceWith(
+      'sample-asset-id'
+    );
+
+    mockEdcClient.listAssets.should.have.been.calledOnceWith({
+      filterExpression: [
+        {
+          operandLeft: 'https://w3id.org/edc/v0.0.1/ns/owner',
+          operandRight: 'provider-client',
+          operator: '=',
+        },
+        {
+          operandLeft: 'https://w3id.org/edc/v0.0.1/ns/sharedWith',
+          operandRight: 'consumer-id',
+          operator: '=',
+        },
+        {
+          operandLeft: 'https://w3id.org/edc/v0.0.1/ns/month',
+          operandRight: +validInput.month,
+          operator: '=',
+        },
+        {
+          operandLeft: 'https://w3id.org/edc/v0.0.1/ns/year',
+          operandRight: +validInput.year,
+          operator: '=',
+        },
+      ],
+    });
+  });
+});

--- a/src/core/usecases/delete-fooprint.ts
+++ b/src/core/usecases/delete-fooprint.ts
@@ -1,11 +1,22 @@
-import { validateSchema } from 'utils/helpers';
-import { ISfcDataSpace } from 'core/usecases/interfaces';
+import { validateData } from 'utils/helpers';
+import { ISFCAPI, ISfcDataSpace } from 'core/usecases/interfaces';
+import { unshareSchema } from 'core/validators';
 
+export type DeleteFootprintInput = {
+  year: string;
+  month: string;
+  companyId: string;
+};
 export class DeleteFootprintUsecase {
-  constructor(private sfcDataSpace: ISfcDataSpace) {}
+  constructor(private sfcAPI: ISFCAPI, private sfcDataSpace: ISfcDataSpace) {}
 
-  async execute(shipmentId: string, companyId: string) {
-    await validateSchema({ shipmentId }, { shipmentId: 'required|string' });
-    await this.sfcDataSpace.unshareFootprint(shipmentId, companyId);
+  async execute(authorization: string, input: DeleteFootprintInput) {
+    const validatedData = await validateData(unshareSchema, input);
+    const sfcConnection = await this.sfcAPI.createConnection(
+      authorization || ''
+    );
+    const provider = await sfcConnection.getMyProfile();
+
+    await this.sfcDataSpace.unshareFootprint(provider.client_id, validatedData);
   }
 }

--- a/src/core/usecases/index.ts
+++ b/src/core/usecases/index.ts
@@ -21,7 +21,11 @@ export const provideFootprintUsecase = new ListSharedAssetsUsecsase(
   sfcDataSpace,
   sfcAPI
 );
-export const deleteFootprintUsecase = new DeleteFootprintUsecase(sfcDataSpace);
+export const deleteFootprintUsecase = new DeleteFootprintUsecase(
+  sfcAPI,
+  sfcDataSpace
+);
+
 export const shareFootprintUsecase = new ShareFootprintUsecase(
   sfcDataSpace,
   dataSourceService,

--- a/src/core/usecases/interfaces.ts
+++ b/src/core/usecases/interfaces.ts
@@ -15,9 +15,18 @@ export type FootprintMetaData = {
   year: number;
   id: string;
 };
+
+export type DeleteAssetInput = {
+  year: string;
+  month: string;
+  companyId: string;
+};
 export interface ISfcDataSpace {
   shareAsset(input: ShareDataspaceAssetInput): Promise<object>;
-  unshareFootprint(shipmentId: string, companyId: string): Promise<void>;
+  unshareFootprint(
+    providerId: string,
+    assetToDelete: DeleteAssetInput
+  ): Promise<void>;
   fetchCarbonFootprint(input): Promise<EmissionDataModel[]>;
   fetchFootprintsMetaData(provider: Participant): Promise<FootprintMetaData[]>;
 

--- a/src/core/validators/index.ts
+++ b/src/core/validators/index.ts
@@ -1,1 +1,2 @@
 export * from './share-footprint-schema';
+export { unshareSchema } from './unshare-schema';

--- a/src/core/validators/unshare-schema.ts
+++ b/src/core/validators/unshare-schema.ts
@@ -1,0 +1,7 @@
+import joi from 'joi';
+
+export const unshareSchema = joi.object({
+  month: joi.number().integer().greater(0).less(13).required(),
+  year: joi.number().required(),
+  companyId: joi.string().required(),
+});

--- a/src/utils/edc-builder.ts
+++ b/src/utils/edc-builder.ts
@@ -95,23 +95,18 @@ function BPNPolicyConstraint(policyBPN: string): Constraint[] {
 
 export function contractDefinition(
   assetId: string,
-  policyId: string
+  policyId: string,
+  assetsSelector: CriterionInput[]
 ): ContractDefinitionInput {
   return {
     '@id': `${assetId}-${randomUid()}`,
     accessPolicyId: policyId,
     contractPolicyId: policyId,
-    assetsSelector: [
-      {
-        operandLeft: 'https://w3id.org/edc/v0.0.1/ns/id',
-        operator: '=',
-        operandRight: assetId,
-      },
-    ],
+    assetsSelector,
   };
 }
 
-export function filter(
+export function assetFilter(
   operandLeft: string,
   operator = '=',
   operandRight: string | number | boolean
@@ -130,7 +125,7 @@ export function shipmentFilter(
 ) {
   if (EDC_FILTER_OPERATOR_SET.has(operator)) {
     return {
-      filterExpression: [filter(operandLeft, operandRight, operator)],
+      filterExpression: [assetFilter(operandLeft, operandRight, operator)],
     };
   }
 

--- a/src/utils/errors/index.ts
+++ b/src/utils/errors/index.ts
@@ -59,6 +59,11 @@ export class ContractNotFound extends NotFound {
   message = 'Contract Not Found';
 }
 
+export class ShipmentForMonthNotFound extends NotFound {
+  name = 'shipment_not_found';
+  message = 'No Shipment that month exists';
+}
+
 export class EmptyDataSource extends InvalidUserInput {
   name = 'empty_datasource';
   message = 'The datasource is empty or has only the header';


### PR DESCRIPTION

## Description
- updates the delete asset call to use latest api
- updates validation that checks whether the shipment exists


### How to test it
- Share an asset
- Delete that asset you shared


## Approach


#### Implementation
This first gets the assets that were shared that month, year and by that owner. If it returns values then it is deleted

#### Testing
I did something a little bit different in the testing. Previously we had been adding tests to both the usecase and the sfc-dataspace. For this PR, I decided to pass the mockEdcClient down in the usecase tests. 

Using this approach, we are also checking the logic of the sfc-dataspace objects that we have been creating. This a slightly different approach but I think it is easier that the former pattern. I don't know if this is the best way to do it though because we ought to treat each interface as independent but It is easier.  

### Open Questions and Pre-Merge TODOs

## Learning
- You can learn a bit more about [dependency injection](https://www.youtube.com/watch?v=J1f5b4vcxCQ) and how it helps in testing
