### PR TITLE
feat: users can login with username and password

### DIFF
--- a/src/api/routes/emissions.ts
+++ b/src/api/routes/emissions.ts
@@ -24,13 +24,6 @@ export const emissionRoutes = new KoaRouter({ prefix: '/emissions' })
     ProviderController.unshareFootprint
   )
 
-  .get(
-    'Request a data catalog from a connector',
-    '/catalog',
-    AuthController.authMiddleware,
-    ProviderController.unshareFootprint
-  )
-
   .post(
     'Validate data model',
     '/validate-data-source',

--- a/src/clients/interfaces.ts
+++ b/src/clients/interfaces.ts
@@ -1,8 +1,8 @@
 import { KeyCloackClient } from './keycloak-client';
 
 export type KeyCloackClientType = typeof KeyCloackClient;
-export type TokenInput = Partial<{
+export type TokenInput = {
   grant_type: string;
-  client_id: string;
-  client_secret: string;
-}>;
+  username: string;
+  password: string;
+};

--- a/src/clients/keycloak-client.ts
+++ b/src/clients/keycloak-client.ts
@@ -1,8 +1,14 @@
 import axios, { AxiosError } from 'axios';
 import url from 'url';
 import jwt from 'jsonwebtoken';
-import { KEYCLOAK_HOST, KEYCLOAK_REALM } from 'utils/settings';
 import {
+  KEYCLOAK_CLIENT_ID,
+  KEYCLOAK_CLIENT_SECRET,
+  KEYCLOAK_HOST,
+  KEYCLOAK_REALM,
+} from 'utils/settings';
+import {
+  AccountNotSetup,
   InvalidCredentials,
   InvalidToken,
   KeyCloakCouldNotGenerateToken,
@@ -38,6 +44,42 @@ export class KeyCloackClient {
       }
       logger.error('Error occured while validating tokes in keycloak', {
         error,
+      });
+      throw new KeyCloakCouldNotGenerateToken();
+    }
+  }
+
+  static async generateTokenWithPassword(username: string, password: string) {
+    try {
+      const body = new url.URLSearchParams({
+        grant_type: 'password',
+        client_id: KEYCLOAK_CLIENT_ID,
+        client_secret: KEYCLOAK_CLIENT_SECRET,
+        username,
+        password,
+      });
+
+      const res = await keyCloakClient.post(
+        '/protocol/openid-connect/token',
+        body
+      );
+
+      return res.data;
+    } catch (error) {
+      const axiosError = error as AxiosError;
+
+      if (axiosError.response?.status === 401) {
+        throw new InvalidCredentials();
+      }
+
+      if (axiosError.response?.status === 400) {
+        throw new AccountNotSetup();
+      }
+      logger.error('Error while logging in user with KeyCloak', {
+        error: {
+          data: axiosError.response?.data,
+          status: axiosError.response?.status,
+        },
       });
       throw new KeyCloakCouldNotGenerateToken();
     }

--- a/src/core/usecases/generate-token.ts
+++ b/src/core/usecases/generate-token.ts
@@ -1,22 +1,22 @@
 import { KeyCloackClientType, TokenInput } from 'clients/interfaces';
-import { validateSchema } from 'utils/helpers';
+import Joi from 'joi';
+import { validateData } from 'utils/helpers';
 
-const generateTokenSchema = {
-  grant_type: ['required', { in: ['client_credentials'] }],
-  client_id: ['required'],
-  client_secret: ['required'],
-};
+const generateTokenSchema = Joi.object({
+  grant_type: Joi.string().valid('password').required(),
+  username: Joi.string().required(),
+  password: Joi.string().required(),
+});
 
 export class GenerateTokenUsecase {
   constructor(private readonly keycloakClient: KeyCloackClientType) {}
 
   async execute(input: TokenInput) {
-    validateSchema(input, generateTokenSchema);
+    const { username, password } = validateData(generateTokenSchema, input);
 
-    const data = await this.keycloakClient.generateToken(
-      input.client_id as string,
-      input.grant_type as string,
-      input.client_secret as string
+    const data = await this.keycloakClient.generateTokenWithPassword(
+      username,
+      password
     );
 
     return {

--- a/src/core/usecases/get-emissions.ts
+++ b/src/core/usecases/get-emissions.ts
@@ -5,11 +5,6 @@ import { TransferNotInitiated } from 'utils/errors';
 
 const logger = new AppLogger('GetEmissionsUsecase');
 
-type AssetCacheValue = {
-  authCode: string;
-  authKey: string;
-};
-
 type JobCacheValue = {
   assetIds: string[];
 };

--- a/src/core/usecases/list-shared-assets.ts
+++ b/src/core/usecases/list-shared-assets.ts
@@ -1,10 +1,15 @@
 import { paginate } from 'utils/paginate';
 import { ISFCAPI, ISfcDataSpace } from './interfaces';
 import { validatePaginationQuery } from 'utils/helpers';
+import { AppLogger } from 'utils/logger';
+const logger = new AppLogger('ShareFootprintUsecase');
+
 export class ListSharedAssetsUsecsase {
   constructor(private sfcDataspace: ISfcDataSpace, private sfcUnit: ISFCAPI) {}
 
   async execute(authorization: string, query) {
+    logger.info('Retrieving assets that I have previously shared...');
+
     const provider = await this.sfcUnit
       .createConnection(authorization)
       .getMyProfile();

--- a/src/utils/errors/index.ts
+++ b/src/utils/errors/index.ts
@@ -45,6 +45,12 @@ export class InvalidCredentials extends Unauthorized {
   name = 'invalid_credentials';
   message = 'Invalid Credentials';
 }
+
+export class AccountNotSetup extends Unauthorized {
+  name = 'account_setup_error';
+  message =
+    'Either you have not reset the password of that user or some setup is incomplete';
+}
 export class ParticipantNotFound extends NotFound {
   name = 'participant_not_found';
   message = 'Participant not found';

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -52,6 +52,9 @@ export const REDIS_DB = process.env.REDIS_DATABASE || '';
 export const KEYCLOAK_REALM = process.env.KEYCLOAK_REALM;
 export const KEYCLOAK_HOST = process.env.KEYCLOAK_HOST;
 export const KEYCLOAK_PUBLIC_KEY = process.env.KEYCLOAK_PUBLIC_KEY || '';
+export const KEYCLOAK_CLIENT_ID = process.env.KEYCLOAK_CLIENT_ID || '';
+export const KEYCLOAK_CLIENT_SECRET = process.env.KEYCLOAK_CLIENT_SECRET || '';
+
 export const SFCAPI_BASEURL = process.env.SFCAPI_BASEURL;
 
 const SUPPORTED_EDC_FILTER_OPERATORS =


### PR DESCRIPTION
## Description
- modifies the login endpoint to take username and password
- adds new method to keyCloak that logs in a user with email and passwod

### How to test it
- You need to create a user on the KeyCloak dashboard
- Create a Password for the user 
- Try to hit the login endpoint and input the username and password of the user. 
- Use the generated token in the api endpionts


Resolves #204 
