### PR TITLE
fix: correct issues with unsharing assets

### DIFF
--- a/src/core/services/sfc-dataspace/__tests__/share-asset.unit.test.ts
+++ b/src/core/services/sfc-dataspace/__tests__/share-asset.unit.test.ts
@@ -53,8 +53,8 @@ describe('SfcDataspace', () => {
       clock.restore();
     });
 
-    it('should throw error when asset has been created previously', async () => {
-      mockEdcClient.listAssets.returns(
+    it('should throw error when contract definitions has been created previously', async () => {
+      mockEdcClient.queryAllContractDefinitions.returns(
         Promise.resolve([
           {
             accessPolicyId: '',
@@ -69,7 +69,7 @@ describe('SfcDataspace', () => {
     });
 
     it('should create an asset on the connector', async () => {
-      mockEdcClient.listAssets.returns(Promise.resolve([]));
+      mockEdcClient.queryAllContractDefinitions.returns(Promise.resolve([]));
       const consumerId = mockConsumer.client_id;
       await sfcDataspace.shareAsset(mockShareAssetInput);
 
@@ -77,9 +77,9 @@ describe('SfcDataspace', () => {
 
       mockEdcClient.createAsset.firstCall.firstArg.should.containSubset({
         properties: {
-          month: mockShareAssetInput.month,
-          numberOfRows: mockShareAssetInput.numberOfRows,
-          year: mockShareAssetInput.year,
+          month: mockShareAssetInput.month.toString(),
+          numberOfRows: mockShareAssetInput.numberOfRows.toString(),
+          year: mockShareAssetInput.year.toString(),
           owner: mockProvider.client_id,
           sharedWith: consumerId,
         },
@@ -98,7 +98,7 @@ describe('SfcDataspace', () => {
     });
 
     it('should correctly create a policy using the companyBPN', async () => {
-      mockEdcClient.listAssets.returns(Promise.resolve([]));
+      mockEdcClient.queryAllContractDefinitions.returns(Promise.resolve([]));
       await sfcDataspace.shareAsset(mockShareAssetInput);
 
       mockEdcClient.createPolicy.should.have.been.calledOnceWithExactly({
@@ -130,7 +130,7 @@ describe('SfcDataspace', () => {
     });
 
     it('should correctly create a contract definitions using the companyBPN', async () => {
-      mockEdcClient.listAssets.returns(Promise.resolve([]));
+      mockEdcClient.queryAllContractDefinitions.returns(Promise.resolve([]));
 
       await sfcDataspace.shareAsset(mockShareAssetInput);
 
@@ -150,12 +150,12 @@ describe('SfcDataspace', () => {
           },
           {
             operandLeft: 'https://w3id.org/edc/v0.0.1/ns/month',
-            operandRight: 10,
+            operandRight: '10',
             operator: '=',
           },
           {
             operandLeft: 'https://w3id.org/edc/v0.0.1/ns/year',
-            operandRight: 2023,
+            operandRight: '2023',
             operator: '=',
           },
           {

--- a/src/utils/edc-builder.ts
+++ b/src/utils/edc-builder.ts
@@ -22,7 +22,7 @@ type ShareAssetInput = ShareFootprintInput & {
 };
 
 export function assetInput(dataInput: ShareAssetInput): AssetInput {
-  const { month, year, dataLocation, type } = dataInput;
+  const { month, year, dataLocation, numberOfRows, type } = dataInput;
 
   const now = new Date();
 
@@ -36,11 +36,11 @@ export function assetInput(dataInput: ShareAssetInput): AssetInput {
   return {
     '@id': assetId,
     properties: {
-      month: dataInput.month,
-      year: dataInput.year,
+      month: Math.floor(month).toString(),
+      year: Math.floor(year).toString(),
       owner: dataInput.providerClientId,
       sharedWith: dataInput.sharedWith,
-      numberOfRows: dataInput.numberOfRows,
+      numberOfRows: Math.floor(numberOfRows).toString(),
     },
     privateProperties: {},
     dataAddress: {
@@ -107,9 +107,28 @@ export function assetFilter(
 ): CriterionInput {
   return {
     operandLeft: `https://w3id.org/edc/v0.0.1/ns/${operandLeft}`,
-    operandRight: operandRight,
+    operandRight: `${operandRight}`,
     operator: operator,
   };
+}
+
+export function contractDefinitionFilter(
+  operandLeft: string,
+  operator = '=',
+  operandRight: string | number | boolean
+): CriterionInput[] {
+  return [
+    {
+      operandLeft: 'assetsSelector.operandRight',
+      operator: operator,
+      operandRight: `${operandRight}`,
+    },
+    {
+      operandLeft: 'assetsSelector.operandLeft',
+      operator: operator,
+      operandRight: `https://w3id.org/edc/v0.0.1/ns/${operandLeft}`,
+    },
+  ];
 }
 
 export function shipmentFilter(


### PR DESCRIPTION
## Description
- Previously when a user deletes an asset that has been a contract agreement, the API fails. The problem was that you cannot delete an asset when it has a contract definition
- We fixed this by deleting the contract definition instead of deleting the asset

### How to test it
- Share a carbon footprint
- Initiate a file transfer 
- Revoke access to the asset.

Resolves #207 
